### PR TITLE
fix firefox jsonview, and other updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,19 @@ WORKDIR /app
 
 # Install python, pip, xvfb
 RUN sudo apt-get -qq update && \
-    sudo apt-get install -y python python-pip python-dev build-essential git && \
-    sudo pip install --upgrade pip
+    sudo apt-get install -y python python-pip python-dev build-essential git libgtk-3-0 libdbus-glib-1-2 && \
+    sudo -H pip install --upgrade pip
 
 # Install selenium
-RUN sudo pip install selenium
+RUN sudo -H pip install selenium
 
 # Install dns_compare
-RUN sudo pip install dnspython git+http://github.com/joemiller/dns_compare.git#egg=dns_compare
+# RUN sudo -H pip install dnspython git+http://github.com/joemiller/dns_compare.git#egg=dns_compare
 
 # Install cli53
-RUN sudo wget -O /usr/local/bin/cli53 https://github.com/barnybug/cli53/releases/download/0.8.12/cli53-linux-amd64 && \
-    sudo chmod +x /usr/local/bin/cli53
+# RUN sudo wget -O /usr/local/bin/cli53 https://github.com/barnybug/cli53/releases/download/0.8.12/cli53-linux-amd64 && \
+#    sudo chmod +x /usr/local/bin/cli53
+
+RUN sudo apt-get -y autoremove
 
 CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,11 @@ RUN sudo apt-get -qq update && \
 RUN sudo -H pip install selenium
 
 # Install dns_compare
-# RUN sudo -H pip install dnspython git+http://github.com/joemiller/dns_compare.git#egg=dns_compare
+RUN sudo -H pip install dnspython git+http://github.com/joemiller/dns_compare.git#egg=dns_compare
 
 # Install cli53
-# RUN sudo wget -O /usr/local/bin/cli53 https://github.com/barnybug/cli53/releases/download/0.8.12/cli53-linux-amd64 && \
-#    sudo chmod +x /usr/local/bin/cli53
+RUN sudo wget -O /usr/local/bin/cli53 https://github.com/barnybug/cli53/releases/download/0.8.12/cli53-linux-amd64 && \
+    sudo chmod +x /usr/local/bin/cli53
 
 RUN sudo apt-get -y autoremove
 

--- a/README.md
+++ b/README.md
@@ -27,20 +27,21 @@ Optional: includes tools and instructios to then create and import that zone to 
     ./get-zone setup
     ```
 
-3. Copy the `.env.example` file to `.env`, and optionally set your AWS credentials if you want to work with Route 53.
+3. Optionally set your AWS credentials if you want to work with Route 53.
 
     ```
-    cp .env.example .env
     vi .env               # Optional: Replace the TODO values if you want to use Route 53
     ```
 
-4. Run the script:
+4. If you are using Docker on macOS, you need to set up file sharing for the project directory. Click the Docker icon > Preferences > File Sharing and add the full path of this project.
+
+5. Run the script:
 
     ```
     ./get-zone run <namecheap_username> <namecheap_password> <domain>
     ```
 
-5. Cross-fingers you don't get CAPTCHA'd.
+6. Cross-fingers you don't get CAPTCHA'd.
 
 
 ## Import Zone to Route 53

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Tries to get your DNS Zone File from NameCheap.
 
 Uses Selenium + Firefox + Xvfb + Docker to login and scrape the DNS info.
 
-Optional: includes tools and instructios to then create and import that zone to AWS Route 53.
+Optional: includes tools and instructions to then create and import that zone to AWS Route 53.
 
 ## Prerequisites
 
@@ -46,23 +46,26 @@ Optional: includes tools and instructios to then create and import that zone to 
 
 ## Import Zone to Route 53
 
-If you made it this far, you can copy that zone file output and paste it into a text file in this directory. Then run bash in the container to get access to the `cli53` tool. Assuming you setup your AWS credentials in Step 3, you can use that to mange your Route 53 account, including creating a new hosted zone and importing this zone file to it. E.g.:
+If you made it this far, you can copy that zone file output and paste it into a text file in this directory. Then run bash in the container to get access to the `cli53` tool. Assuming you setup your AWS credentials in Step 3, you can use that to mange your Route 53 account, including creating a new hosted zone and importing this zone file to it. e.g.:
 
-    ```
-    cli53 list                 # List your current set of zones
-    cli53 export example.com   # export an existing zone file as a backup
-    ```
+```
+cli53 list                 # List your current set of zones
+cli53 export example.com   # export an existing zone file as a backup
+```
 
 To create and import this zone file to Route 53:
 
-    ```
-    cli53 create example.com                           # replace example.com with your domain
-    cli53 import example.com --file example.com.zone   # the file you saved your NameCheap zone data to
-    ```
+```
+cli53 create example.com                           # replace example.com with your domain
+cli53 import example.com --file example.com.zone   # the file you saved your NameCheap zone data to
+```
 
 For more info on `cli53`, see: https://github.com/barnybug/cli53
 
-This Docker image also has `dns_compare` installed, which can be used to compare your zone file against a server. Use it to compare your extracted NameCheap zone file to the NameCheap server to make sure it is the same. And then to the Route 53 nameserver - it should be the same too. That's how you know they are identical before you flip the switch at NameCheap to point to Route 53 nameservers. (ProTip: Set your NS record TTLs at NameCheap to be low before you start all this, then set them back up to be high in Route 53 after all is well.) For more info on `dns_compare` see: https://github.com/joemiller/dns_compare
+This Docker image also has `dns_compare` installed, which can be used to compare your zone file against a server. Use it to compare your extracted NameCheap zone file to the NameCheap server to make sure it is the same. And then to the Route 53 nameserver - it should be the same too. That's how you know they are identical before you flip the switch at NameCheap to point to Route 53 nameservers. (ProTip: Set your NS record TTLs at NameCheap to be low before you start all this, then set them back up to be high in Route 53 after all is well.)
+
+For more info on `dns_compare` see: https://github.com/joemiller/dns_compare
+
 
 ## TODO
 
@@ -72,6 +75,4 @@ This Docker image also has `dns_compare` installed, which can be used to compare
 
 ## Credits
 
-Orignal core script from:
-
-https://gist.github.com/judotens/151341f04b37ffeb5b59
+Original core script from: https://gist.github.com/judotens/151341f04b37ffeb5b59

--- a/get-zone
+++ b/get-zone
@@ -19,11 +19,12 @@ if [[ $# -lt 1 ]]; then
 fi
 
 while [[ $# -gt 0 ]]; do
-  param="$1" 
+  param="$1"
   case "$param" in
     setup)
     echo "Building get-namecheap-zone-file Docker container..."
     docker build . -t get-namecheap-zone-file
+    rsync -c .env.example .env
     ;;
 
     run)


### PR DESCRIPTION
- new firefox versions ship with `jsonview` preference enabled, which turns json into pretty print html and breaks tool; i have fixed this by passing in a firefox profile to webdriver with it disabled
- gets rid of `pip` `sudo` warnings
- adds required gtk3 libs to `apt-get install`
- updated `README` with additional macOS instruction for shared folders
- `setup` creates local `.env` file for user now
- wait for login form to appear, instead of sleeping for arbitrary number of seconds
- indentation