### PR TITLE
2022 working update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,19 @@ WORKDIR /app
 
 # Install python, pip, xvfb
 RUN sudo apt-get -qq update && \
-    sudo apt-get install -y python python-pip python-dev build-essential git && \
-    sudo pip install --upgrade pip
+    sudo apt-get install -y python python-pip python-dev build-essential git libgtk-3-0 libdbus-glib-1-2 && \
+    sudo -H pip install --upgrade pip
 
 # Install selenium
-RUN sudo pip install selenium
+RUN sudo -H pip install selenium
 
 # Install dns_compare
-RUN sudo pip install dnspython git+http://github.com/joemiller/dns_compare.git#egg=dns_compare
+# RUN sudo -H pip install dnspython git+http://github.com/joemiller/dns_compare.git#egg=dns_compare
 
 # Install cli53
-RUN sudo wget -O /usr/local/bin/cli53 https://github.com/barnybug/cli53/releases/download/0.8.12/cli53-linux-amd64 && \
-    sudo chmod +x /usr/local/bin/cli53
+# RUN sudo wget -O /usr/local/bin/cli53 https://github.com/barnybug/cli53/releases/download/0.8.12/cli53-linux-amd64 && \
+#    sudo chmod +x /usr/local/bin/cli53
+
+RUN sudo apt-get -y autoremove
 
 CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/standalone-firefox
+FROM selenium/standalone-firefox:3.14.0
 WORKDIR /app
 
 # Install python, pip, xvfb

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,11 @@ RUN sudo apt-get -qq update && \
 RUN sudo -H pip install selenium
 
 # Install dns_compare
-# RUN sudo -H pip install dnspython git+http://github.com/joemiller/dns_compare.git#egg=dns_compare
+RUN sudo -H pip install dnspython git+http://github.com/joemiller/dns_compare.git#egg=dns_compare
 
 # Install cli53
-# RUN sudo wget -O /usr/local/bin/cli53 https://github.com/barnybug/cli53/releases/download/0.8.12/cli53-linux-amd64 && \
-#    sudo chmod +x /usr/local/bin/cli53
+RUN sudo wget -O /usr/local/bin/cli53 https://github.com/barnybug/cli53/releases/download/0.8.12/cli53-linux-amd64 && \
+    sudo chmod +x /usr/local/bin/cli53
 
 RUN sudo apt-get -y autoremove
 

--- a/README.md
+++ b/README.md
@@ -4,49 +4,47 @@ Tries to get your DNS Zone File from NameCheap.
 
 Uses Selenium + Firefox + Xvfb + Docker to login and scrape the DNS info.
 
-Optional: includes tools and instructions to then create and import that zone to AWS Route 53.
-
 ## Prerequisites
 
-  * Bash
-  * Docker
-
+- Bash
+- Docker
 
 ## Usage
 
+0. Enable TOTP 2FA on your Namecheap account to avoid an email challenge.
+
 1. Clone this repository:
 
-    ```
-    git clone git@github.com:facetdigital/get-namecheap-zone-file.git
-    ```
+   ```
+   git clone git@github.com:facetdigital/get-namecheap-zone-file.git
+   ```
 
 2. Build the docker container:
 
-    ```
-    cd get-namecheap-zone-file
-    ./get-zone setup
-    ```
+   ```
+   cd get-namecheap-zone-file
+   ./get-zone setup
+   ```
 
-3. Optionally set your AWS credentials if you want to work with Route 53.
+3a. Run the script:
 
-    ```
-    vi .env               # Optional: Replace the TODO values if you want to use Route 53
-    ```
+```
+./get-zone run <domain>
+```
 
-4. If you are using Docker on macOS, you need to set up file sharing for the project directory. Click the Docker icon > Preferences > File Sharing and add the full path of this project.
+3b. Re-run repeatedly until it works. Yeah. Namecheap inconsistently send the TOTP challenge page to Selenium, or the Python code is badly done.
 
-5. Run the script:
+4. Copy the zone output to a .zone file
 
-    ```
-    ./get-zone run <namecheap_username> <namecheap_password> <domain>
-    ```
+## Import Zone
 
-6. Cross-fingers you don't get CAPTCHA'd.
+### Cloudflare
 
+You can simply drag the zone file into Cloudflare's DNS page and import it.
 
-## Import Zone to Route 53
+### Route 53
 
-If you made it this far, you can copy that zone file output and paste it into a text file in this directory. Then run bash in the container to get access to the `cli53` tool. Assuming you setup your AWS credentials in Step 3, you can use that to mange your Route 53 account, including creating a new hosted zone and importing this zone file to it. e.g.:
+Run bash in the container to get access to the `cli53` tool. You can use that to mange your Route 53 account, including creating a new hosted zone and importing this zone file to it. e.g.:
 
 ```
 cli53 list                 # List your current set of zones
@@ -62,16 +60,15 @@ cli53 import example.com --file example.com.zone   # the file you saved your Nam
 
 For more info on `cli53`, see: https://github.com/barnybug/cli53
 
+## dns_compare
+
 This Docker image also has `dns_compare` installed, which can be used to compare your zone file against a server. Use it to compare your extracted NameCheap zone file to the NameCheap server to make sure it is the same. And then to the Route 53 nameserver - it should be the same too. That's how you know they are identical before you flip the switch at NameCheap to point to Route 53 nameservers. (ProTip: Set your NS record TTLs at NameCheap to be low before you start all this, then set them back up to be high in Route 53 after all is well.)
 
 For more info on `dns_compare` see: https://github.com/joemiller/dns_compare
 
-
 ## TODO
 
-  * [ ] Make a Chrome Extension version of this you can run when already logged in.
-  * [ ] Make it call Route 53 API to upload zone file. One command to migrate from NameCheap to Route 53!
-
+- [ ] Make a Chrome Extension version of this you can run when already logged in.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -27,20 +27,21 @@ Optional: includes tools and instructios to then create and import that zone to 
     ./get-zone setup
     ```
 
-3. Copy the `.env.example` file to `.env`, and optionally set your AWS credentials if you want to work with Route 53.
+3. Optionally set your AWS credentials if you want to work with Route 53.
 
     ```
-    cp .env.example .env
     vi .env               # Optional: Replace the TODO values if you want to use Route 53
     ```
 
-4. Run the script:
+4. If you are using Docker on macOS, you need to set up file sharing for the project directory. Click the Docker icon > Preferences > File Sharing and add the full path of this project.
+
+5. Run the script:
 
     ```
     ./get-zone run <namecheap_username> <namecheap_password> <domain>
     ```
 
-5. Cross-fingers you don't get CAPTCHA'd.
+6. Cross-fingers you don't get CAPTCHA'd.
 
 
 ## Import Zone to Route 53

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Tries to get your DNS Zone File from NameCheap.
 
 Uses Selenium + Firefox + Xvfb + Docker to login and scrape the DNS info.
 
-Optional: includes tools and instructios to then create and import that zone to AWS Route 53.
+Optional: includes tools and instructions to then create and import that zone to AWS Route 53.
 
 ## Prerequisites
 
@@ -46,23 +46,26 @@ Optional: includes tools and instructios to then create and import that zone to 
 
 ## Import Zone to Route 53
 
-If you made it this far, you can copy that zone file output and paste it into a text file in this directory. Then run bash in the container to get access to the `cli53` tool. Assuming you setup your AWS credentials in Step 3, you can use that to mange your Route 53 account, including creating a new hosted zone and importing this zone file to it. E.g.:
+If you made it this far, you can copy that zone file output and paste it into a text file in this directory. Then run bash in the container to get access to the `cli53` tool. Assuming you setup your AWS credentials in Step 3, you can use that to mange your Route 53 account, including creating a new hosted zone and importing this zone file to it. e.g.:
 
-    ```
-    cli53 list                 # List your current set of zones
-    cli53 export example.com   # export an existing zone file as a backup
-    ```
+```
+cli53 list                 # List your current set of zones
+cli53 export example.com   # export an existing zone file as a backup
+```
 
 To create and import this zone file to Route 53:
 
-    ```
-    cli53 create example.com                           # replace example.com with your domain
-    cli53 import example.com --file example.com.zone   # the file you saved your NameCheap zone data to
-    ```
+```
+cli53 create example.com                           # replace example.com with your domain
+cli53 import example.com --file example.com.zone   # the file you saved your NameCheap zone data to
+```
 
 For more info on `cli53`, see: https://github.com/barnybug/cli53
 
-This Docker image also has `dns_compare` installed, which can be used to compare your zone file against a server. Use it to compare your extracted NameCheap zone file to the NameCheap server to make sure it is the same. And then to the Route 53 nameserver - it should be the same too. That's how you know they are identical before you flip the switch at NameCheap to point to Route 53 nameservers. (ProTip: Set your NS record TTLs at NameCheap to be low before you start all this, then set them back up to be high in Route 53 after all is well.) For more info on `dns_compare` see: https://github.com/joemiller/dns_compare
+This Docker image also has `dns_compare` installed, which can be used to compare your zone file against a server. Use it to compare your extracted NameCheap zone file to the NameCheap server to make sure it is the same. And then to the Route 53 nameserver - it should be the same too. That's how you know they are identical before you flip the switch at NameCheap to point to Route 53 nameservers. (ProTip: Set your NS record TTLs at NameCheap to be low before you start all this, then set them back up to be high in Route 53 after all is well.)
+
+For more info on `dns_compare` see: https://github.com/joemiller/dns_compare
+
 
 ## TODO
 
@@ -72,6 +75,4 @@ This Docker image also has `dns_compare` installed, which can be used to compare
 
 ## Credits
 
-Orignal core script from:
-
-https://gist.github.com/judotens/151341f04b37ffeb5b59
+Original core script from: https://gist.github.com/judotens/151341f04b37ffeb5b59

--- a/get-zone
+++ b/get-zone
@@ -7,7 +7,7 @@ if [[ $# -lt 1 ]]; then
   echo "Commands:"
   echo "  setup - Setup the necessary Docker container."
   echo
-  echo "  run <namecheap_username> <namecheap_password> <domain> - Run the script to get your NameCheap DNS Zone File."
+  echo "  run <domain> - Run the script to get your NameCheap DNS Zone File."
   echo
   echo "  bash - Run bash in the container environment."
   echo
@@ -21,28 +21,27 @@ fi
 while [[ $# -gt 0 ]]; do
   param="$1"
   case "$param" in
-    setup)
+  setup)
     echo "Building get-namecheap-zone-file Docker container..."
     docker build . -t get-namecheap-zone-file
     rsync -c .env.example .env
     ;;
 
-    run)
+  run)
     shift
     docker run -it --init --rm -v $(pwd):/app:cached --shm-size=2g --env-file=.env get-namecheap-zone-file ./wrapper.sh $@
     break
     ;;
 
-    bash)
+  bash)
     docker run -it --rm -v $(pwd):/app:cached --shm-size=2g --env-file=.env get-namecheap-zone-file bash
     break
     ;;
 
-    *)
+  *)
     echo "Unknown command: $param"
     break
     ;;
   esac
   shift
 done
-

--- a/get-zone
+++ b/get-zone
@@ -29,7 +29,7 @@ while [[ $# -gt 0 ]]; do
 
     run)
     shift
-    docker run -it --rm -v $(pwd):/app:cached --shm-size=2g --env-file=.env get-namecheap-zone-file ./wrapper.sh $@
+    docker run -it --init --rm -v $(pwd):/app:cached --shm-size=2g --env-file=.env get-namecheap-zone-file ./wrapper.sh $@
     break
     ;;
 

--- a/get-zone
+++ b/get-zone
@@ -19,11 +19,12 @@ if [[ $# -lt 1 ]]; then
 fi
 
 while [[ $# -gt 0 ]]; do
-  param="$1" 
+  param="$1"
   case "$param" in
     setup)
     echo "Building get-namecheap-zone-file Docker container..."
     docker build . -t get-namecheap-zone-file
+    rsync -c .env.example .env
     ;;
 
     run)

--- a/namecheap.py
+++ b/namecheap.py
@@ -30,8 +30,10 @@ def get_advanced_dns_info(username, password, domain):
     fp = webdriver.FirefoxProfile()
     fp.set_preference("devtools.jsonview.enabled", False)
 
-    print "Requesting advanced DNS page..."
-    browser = webdriver.Firefox(firefox_profile=fp)
+    print "Starting headless browser"
+    browser = webdriver.Firefox(firefox_profile=fp, firefox_options=options)
+
+    print "Requesting Advanced DNS page"
     browser.get('https://ap.www.namecheap.com/Domains/DomainControlPanel/%s/advancedns' % str(domain))
 
     try:
@@ -91,13 +93,15 @@ def parse_dns_info(dns_info):
     return items
 
 if __name__ == "__main__":
+    username = raw_input("Username: ")
+    password = raw_input("Password: ")
     try:
-        dns_info = get_advanced_dns_info(sys.argv[1], sys.argv[2], sys.argv[3])
+        dns_info = get_advanced_dns_info(username, password, sys.argv[1])
     except Exception, e:
         print str(e)
-        sys.exit("Usage: %s <namecheap_username> <namecheap_password> <domain_to_check>" % str(sys.argv[0]))
+        sys.exit("Usage: %s <domain_to_check>" % str(sys.argv[0]))
 
-    print "$ORIGIN %s." % (str(sys.argv[3]))
+    print "$ORIGIN %s." % (str(sys.argv[1]))
     zones = parse_dns_info(dns_info)
 
     for zone in zones:

--- a/namecheap.py
+++ b/namecheap.py
@@ -50,12 +50,14 @@ def get_advanced_dns_info(username, password, domain):
     elem.send_keys(Keys.RETURN)
     time.sleep(5)
 
-    print "Checking to see if there is a CAPTCHA..."
-    try:
-      checkbox = browser.find_element_by_class_name("recaptcha-checkbox-checkmark")
-      print "  Doh! There is a CAPTCHA. This is probably going to fail..."
-    except NoSuchElementException:
-      print "  Whew! There is no CAPTCHA. This might work..."
+    print "Filling out 2FA code"
+    two_factor_code = raw_input("2FA Code: ")
+    browser.get('https://www.namecheap.com/twofa/totp')
+    time.sleep(5)
+    elem = browser.find_element_by_xpath("//form[@class='gb-totp-form']//input")
+    elem.value = str(two_factor_code)
+    elem.send_keys(Keys.RETURN)
+    time.sleep(5)
 
     print "Getting the DNS info as JSON"
     browser.get('https://ap.www.namecheap.com/Domains/dns/GetAdvancedDnsInfo?domainName=%s' % str(domain))

--- a/namecheap.py
+++ b/namecheap.py
@@ -26,7 +26,6 @@ import time
 def get_advanced_dns_info(username, password, domain):
     loginform_timeout = 60
 
-    # stop firefox's new jsonview from breaking everything
     fp = webdriver.FirefoxProfile()
     fp.set_preference("devtools.jsonview.enabled", False)
 
@@ -43,13 +42,12 @@ def get_advanced_dns_info(username, password, domain):
         print "Timed out waiting for correct page to load"
         sys.exit(1)
 
-    print "Filling out login form..."
+    print "Filling out login form"
     elem = browser.find_element_by_class_name("loginForm").find_element_by_name('LoginUserName')
-    elem.send_keys(str(username))
-
+    elem.value = str(username)
     elem = browser.find_element_by_class_name("loginForm").find_element_by_name('LoginPassword')
-    elem.send_keys(str(password) + Keys.RETURN)
-    print "Waiting 5 seconds for login to complete..."
+    elem.value = str(password)
+    elem.send_keys(Keys.RETURN)
     time.sleep(5)
 
     print "Checking to see if there is a CAPTCHA..."
@@ -59,14 +57,14 @@ def get_advanced_dns_info(username, password, domain):
     except NoSuchElementException:
       print "  Whew! There is no CAPTCHA. This might work..."
 
-    print "Trying to get the DNS info as JSON..."
+    print "Getting the DNS info as JSON"
     browser.get('https://ap.www.namecheap.com/Domains/dns/GetAdvancedDnsInfo?domainName=%s' % str(domain))
     isi = browser.find_element_by_tag_name('body').text
     browser.quit()
 
     js = json.loads(isi)
 
-    print "I think we are in the clear. Here is your DNS Zone File:\n\n"
+    print "Here is your DNS Zone File:\n\n"
     return js
 
 def parse_dns_info(dns_info):

--- a/namecheap.py
+++ b/namecheap.py
@@ -24,10 +24,14 @@ import sys
 import time
 
 def get_advanced_dns_info(username, password, domain):
-    loginform_timeout = 60
+    loginform_timeout = 10
 
     fp = webdriver.FirefoxProfile()
+    useragent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:101.0) Gecko/20100101 Firefox/101.0"
+    fp.set_preference("general.useragent.override", useragent)
     fp.set_preference("devtools.jsonview.enabled", False)
+    options = webdriver.FirefoxOptions()
+    options.add_argument('--headless')
 
     print "Starting headless browser"
     browser = webdriver.Firefox(firefox_profile=fp, firefox_options=options)


### PR DESCRIPTION
* Pin firefox to a known-working version
* Fix ctrl-c
* No longer accept credentials on the CLI, instead do so interactively
* Require support for TOTP 2FA to avoid CAPTCHA and an email challenge
* Disentangle this from Route53; this is a good zone-export tool on its own and this just confuses its purpose
* Integrate improvements from #2 